### PR TITLE
updated script for conversational repository name change

### DIFF
--- a/install_for_lcnc.sh
+++ b/install_for_lcnc.sh
@@ -120,7 +120,7 @@ then
 		echo "Developer ProbeBasic install started"
 		cd ~/dev
 		git clone https://github.com/kcjengr/probe_basic.git
-		git clone https://github.com/kcjengr/qtpyvcp.conversational-gcode.git
+		git clone https://github.com/kcjengr/qtpyvcp_conversational_gcode.git
 		
 		cd ~/dev/probe_basic
 		git checkout origin/python3
@@ -128,7 +128,7 @@ then
 		python3 -m pip install --no-deps -e .
 		cp -r ~/dev/probe_basic/config/probe_basic/ ~/linuxcnc/configs/
 		
-		cd ~/dev/qtpyvcp.conversational-gcode
+		cd ~/dev/qtpyvcp_conversational_gcode
 		git checkout origin/python3
 		python3 -m pip install -e .
 	fi

--- a/updater.sh
+++ b/updater.sh
@@ -56,7 +56,7 @@ then
 		git pull
 		qcompile .
 		
-		cd ~/dev/qtpyvcp.conversational-gcode
+		cd ~/dev/qtpyvcp_conversational_gcode
 		git pull
 	fi
 fi


### PR DESCRIPTION
Joco, versioneer needed to be updated and we had to change the repository name because it would not accept it when trying to create the version.py file needed for installation.  I have updated to the new repository name in the pull request and it should start working again. 